### PR TITLE
カスタム絵文字の先行登録実装

### DIFF
--- a/src/components/pages/settings/customEmojis/index.tsx
+++ b/src/components/pages/settings/customEmojis/index.tsx
@@ -15,13 +15,13 @@ export function CustomEmojisIndex(props: { emojis: CustomEmoji[] }) {
                 <tr>
                     <th>画像</th>
                     <th>
-                        <a href="?order=name">shortcode</a>
+                        <a href="?sort=name">shortcode</a>
                     </th>
                     <th>
-                        <a href="?order=uploader">登録者</a>
+                        <a href="?sort=uploader">登録者</a>
                     </th>
                     <th>
-                        <a href="?order=date">登録日時</a>
+                        <a href="?sort=date">登録日時</a>
                     </th>
                 </tr>
                 {props.emojis.map(emoji => (

--- a/src/components/pages/settings/customEmojis/index.tsx
+++ b/src/components/pages/settings/customEmojis/index.tsx
@@ -26,12 +26,19 @@ export function CustomEmojisIndex(props: { emojis: CustomEmoji[] }) {
                 </tr>
                 {props.emojis.map(emoji => (
                     <tr key={emoji.id}>
-                        <td>
-                            <img src={S3_PUBLIC_URL + getPathFromHash(emoji.hash)} style={{ height: "2em" }} />
+                        <td style={{ lineHeight: 0 }}>
+                            <a href={S3_PUBLIC_URL + getPathFromHash(emoji.hash)}>
+                                <img
+                                    src={S3_PUBLIC_URL + getPathFromHash(emoji.hash)}
+                                    style={{ height: "2em", width: "auto" }}
+                                    width={emoji.width}
+                                    height={emoji.height}
+                                />
+                            </a>
                         </td>
                         <td>{emoji.shortcode}</td>
                         <td>@{emoji.user.screenName}</td>
-                        <td>{emoji.createdAt}</td>
+                        <td>{emoji.createdAt.toString()}</td>
                     </tr>
                 ))}
             </table>

--- a/src/components/pages/settings/customEmojis/index.tsx
+++ b/src/components/pages/settings/customEmojis/index.tsx
@@ -10,7 +10,6 @@ export function CustomEmojisIndex(props: { emojis: CustomEmoji[] }) {
             <h1>カスタム絵文字</h1>
             <h2>登録</h2>
             <a href="/settings/custom_emojis/new">画像を登録</a>
-            <a href="/settings/custom_emojis/new_alias">エイリアスを登録</a>
             <h2>リスト</h2>
             <table {...{ border: 1 }}>
                 <tr>

--- a/src/components/pages/settings/customEmojis/index.tsx
+++ b/src/components/pages/settings/customEmojis/index.tsx
@@ -4,7 +4,7 @@ import { CustomEmoji } from "../../../../db/entities/customEmoji"
 import { getPathFromHash } from "../../../../utils/getPathFromHash"
 import { S3_PUBLIC_URL } from "../../../../config"
 
-export function CustomEmojisIndex(props: { csrf: string; emojis: CustomEmoji[] }) {
+export function CustomEmojisIndex(props: { emojis: CustomEmoji[] }) {
     return (
         <Wrapper>
             <h1>カスタム絵文字</h1>
@@ -12,15 +12,18 @@ export function CustomEmojisIndex(props: { csrf: string; emojis: CustomEmoji[] }
             <a href="/settings/custom_emojis/new">画像を登録</a>
             <a href="/settings/custom_emojis/new_alias">エイリアスを登録</a>
             <h2>リスト</h2>
-            並び換え:
-            <a href="?order=date">最近登録された順</a>
-            <a href="?order=name">名前順</a>
-            <a href="?order=uploader">登録者順</a>
             <table {...{ border: 1 }}>
                 <tr>
                     <th>画像</th>
-                    <th>shortcode</th>
-                    <th>登録者</th>
+                    <th>
+                        <a href="?order=name">shortcode</a>
+                    </th>
+                    <th>
+                        <a href="?order=uploader">登録者</a>
+                    </th>
+                    <th>
+                        <a href="?order=date">登録日時</a>
+                    </th>
                 </tr>
                 {props.emojis.map(emoji => (
                     <tr key={emoji.id}>
@@ -29,6 +32,7 @@ export function CustomEmojisIndex(props: { csrf: string; emojis: CustomEmoji[] }
                         </td>
                         <td>{emoji.shortcode}</td>
                         <td>@{emoji.user.screenName}</td>
+                        <td>{emoji.createdAt}</td>
                     </tr>
                 ))}
             </table>

--- a/src/components/pages/settings/customEmojis/index.tsx
+++ b/src/components/pages/settings/customEmojis/index.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { Wrapper } from "../../../common/wrapper"
+import { CustomEmoji } from "../../../../db/entities/customEmoji"
+import { getPathFromHash } from "../../../../utils/getPathFromHash"
+import { S3_PUBLIC_URL } from "../../../../config"
+
+export function CustomEmojisIndex(props: { csrf: string; emojis: CustomEmoji[] }) {
+    return (
+        <Wrapper>
+            <h1>カスタム絵文字</h1>
+            <h2>登録</h2>
+            <a href="/settings/custom_emojis/new">画像を登録</a>
+            <a href="/settings/custom_emojis/new_alias">エイリアスを登録</a>
+            <h2>リスト</h2>
+            並び換え:
+            <a href="?order=date">最近登録された順</a>
+            <a href="?order=name">名前順</a>
+            <a href="?order=uploader">登録者順</a>
+            <table {...{ border: 1 }}>
+                <tr>
+                    <th>画像</th>
+                    <th>shortcode</th>
+                    <th>登録者</th>
+                </tr>
+                {props.emojis.map(emoji => (
+                    <tr key={emoji.id}>
+                        <td>
+                            <img src={S3_PUBLIC_URL + getPathFromHash(emoji.hash)} style={{ height: "2em" }} />
+                        </td>
+                        <td>{emoji.shortcode}</td>
+                        <td>@{emoji.user.screenName}</td>
+                    </tr>
+                ))}
+            </table>
+        </Wrapper>
+    )
+}

--- a/src/components/pages/settings/customEmojis/new.tsx
+++ b/src/components/pages/settings/customEmojis/new.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { Wrapper } from "../../../common/wrapper"
+
+export function CustomEmojisNew(props: { csrf: string }) {
+    return (
+        <Wrapper>
+            <h1>カスタム絵文字を登録</h1>
+            <form method="POST" encType="multipart/form-data">
+                <input type="hidden" name="_csrf" value={props.csrf} />
+                <dl>
+                    <dt>shortcode</dt>
+                    <dd>
+                        :<input type="text" name="shortcode" required maxLength={32} pattern="[A-Za-z0-9_]+" />:
+                    </dd>
+                    <dt>画像</dt>
+                    <dd>
+                        <input type="file" name="file" accept="image/jpeg, image/png" />
+                        <br />
+                        pngかjpeg、256KB以内、縦横比1:2〜2:1、アニメーションは無視
+                    </dd>
+                </dl>
+                <input type="submit" value="登録" />
+            </form>
+        </Wrapper>
+    )
+}

--- a/src/components/pages/settings/customEmojis/new.tsx
+++ b/src/components/pages/settings/customEmojis/new.tsx
@@ -10,7 +10,16 @@ export function CustomEmojisNew(props: { csrf: string }) {
                 <dl>
                     <dt>shortcode</dt>
                     <dd>
-                        :<input type="text" name="shortcode" required maxLength={32} pattern="[A-Za-z0-9_]+" />:
+                        :
+                        <input
+                            type="text"
+                            name="shortcode"
+                            required
+                            maxLength={32}
+                            pattern="^[A-Za-z0-9_]+$"
+                            placeholder="^[A-Za-z0-9_]{1,32}$"
+                        />
+                        :
                     </dd>
                     <dt>画像</dt>
                     <dd>

--- a/src/db/entities/customEmoji.ts
+++ b/src/db/entities/customEmoji.ts
@@ -17,6 +17,12 @@ export class CustomEmoji extends EntityWithTimestamps {
     @Column({ type: "varchar", nullable: false })
     hash!: string
 
+    @Column({ type: "int", nullable: false })
+    width!: number
+
+    @Column({ type: "int", nullable: false })
+    height!: number
+
     @Column({ name: "deleted_at", type: "timestamptz", nullable: true })
     deletedAt!: Date | null
 }

--- a/src/db/entities/customEmoji.ts
+++ b/src/db/entities/customEmoji.ts
@@ -7,7 +7,7 @@ export class CustomEmoji extends EntityWithTimestamps {
     @PrimaryColumn()
     id!: number
 
-    @Column({ type: "citext", nullable: false })
+    @Column({ nullable: false })
     shortcode!: string
 
     @ManyToOne(type => User)

--- a/src/db/entities/customEmoji.ts
+++ b/src/db/entities/customEmoji.ts
@@ -1,0 +1,22 @@
+import { EntityWithTimestamps } from "../../utils/timestampColumns"
+import { PrimaryColumn, ManyToOne, JoinColumn, Column, Entity } from "typeorm"
+import { User } from "./user"
+
+@Entity("custom_emojis")
+export class CustomEmoji extends EntityWithTimestamps {
+    @PrimaryColumn()
+    id!: number
+
+    @Column({ type: "citext", nullable: false })
+    shortcode!: string
+
+    @ManyToOne(type => User)
+    @JoinColumn({ name: "user_id", referencedColumnName: "id" })
+    user!: User
+
+    @Column({ type: "varchar", nullable: false })
+    hash!: string
+
+    @Column({ name: "deleted_at", type: "timestamptz", nullable: true })
+    deletedAt!: Date | null
+}

--- a/src/db/migrations/1579317432813-CreateCustomEmojisTable.ts
+++ b/src/db/migrations/1579317432813-CreateCustomEmojisTable.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm"
+import { timestampColumns } from "../../utils/timestampColumns"
+
+export class CreateCustomEmojisTable1579317432813 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.createTable(
+            new Table({
+                name: "custom_emojis",
+                columns: [
+                    {
+                        name: "id",
+                        type: "int",
+                        isPrimary: true,
+                        isGenerated: true,
+                    },
+                    {
+                        name: "shortcode",
+                        type: "citext",
+                        isNullable: false,
+                    },
+                    {
+                        name: "user_id",
+                        type: "int",
+                        isNullable: false,
+                    },
+                    {
+                        name: "hash",
+                        type: "varchar",
+                        length: "128",
+                        isNullable: false,
+                    },
+                    {
+                        name: "width",
+                        type: "int",
+                        isNullable: false,
+                    },
+                    {
+                        name: "height",
+                        type: "int",
+                        isNullable: false,
+                    },
+                    ...timestampColumns.forMigrations,
+                    {
+                        name: "deleted_at",
+                        type: "timestamptz",
+                    },
+                ],
+                foreignKeys: [
+                    {
+                        name: "FK:custom_emojis:hash::storage_files:hash",
+                        columnNames: ["hash"],
+                        referencedTableName: "storage_files",
+                        referencedColumnNames: ["hash"],
+                    },
+                    {
+                        name: "FK:custom_emojis:user_id::users::id",
+                        columnNames: ["user_id"],
+                        referencedTableName: "users",
+                        referencedColumnNames: ["id"],
+                    },
+                ],
+                indices: [
+                    {
+                        name: "IDX:custom_emojis:shortcode:::not_deleted",
+                        columnNames: ["shortcode"],
+                        where: "deleted_at IS NULL",
+                        isUnique: true,
+                    },
+                ],
+            })
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.dropTable("custom_emojis")
+    }
+}

--- a/src/db/migrations/1579317432813-CreateCustomEmojisTable.ts
+++ b/src/db/migrations/1579317432813-CreateCustomEmojisTable.ts
@@ -43,6 +43,7 @@ export class CreateCustomEmojisTable1579317432813 implements MigrationInterface 
                     {
                         name: "deleted_at",
                         type: "timestamptz",
+                        isNullable: true,
                     },
                 ],
                 foreignKeys: [

--- a/src/db/migrations/1579318658309-AddSizeToStorageFile.ts
+++ b/src/db/migrations/1579318658309-AddSizeToStorageFile.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm"
+
+export class AddSizeToStorageFile1579318658309 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.addColumn(
+            "storage_files",
+            new TableColumn({
+                name: "size",
+                type: "int",
+                isNullable: true,
+            })
+        )
+        await queryRunner.query(
+            "UPDATE storage_files SET size=(SELECT size FROM album_file_variants WHERE hash=storage_files.hash LIMIT 1)"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.dropColumn("storage_files", "size")
+    }
+}

--- a/src/db/repositories/customEmoji.ts
+++ b/src/db/repositories/customEmoji.ts
@@ -1,0 +1,26 @@
+import { CustomEmoji } from "../entities/customEmoji"
+import { Repository, EntityRepository } from "typeorm"
+import { S3_PUBLIC_URL } from "../../config"
+import { getPathFromHash } from "../../utils/getPathFromHash"
+
+@EntityRepository(CustomEmoji)
+export class CustomEmojiRepository extends Repository<CustomEmoji> {
+    async pack(emoji: CustomEmoji) {
+        return {
+            id: emoji.id,
+            shortcode: emoji.shortcode,
+            size: {
+                width: emoji.width,
+                height: emoji.height,
+            },
+            url: `${S3_PUBLIC_URL}${getPathFromHash(emoji.hash)}`,
+            isDeleted: emoji.deletedAt != null,
+            createdAt: emoji.createdAt,
+            updatedAt: emoji.updatedAt,
+        }
+    }
+
+    async packMany(emojis: CustomEmoji[]) {
+        return await Promise.all(emojis.map(e => this.pack(e)))
+    }
+}

--- a/src/routers/api/v1/customEmojis.ts
+++ b/src/routers/api/v1/customEmojis.ts
@@ -1,0 +1,12 @@
+import { CustomEmoji } from "../../../db/entities/customEmoji"
+import { getRepository, IsNull } from "typeorm"
+import { APIRouter } from "../router-class"
+import { CustomEmojiRepository } from "../../../db/repositories/customEmoji"
+
+const router = new APIRouter()
+
+router.get("/", async ctx => {
+    await ctx.sendMany(CustomEmojiRepository, await getRepository(CustomEmoji).find({ deletedAt: IsNull() }))
+})
+
+export default router

--- a/src/routers/api/v1/index.ts
+++ b/src/routers/api/v1/index.ts
@@ -3,6 +3,7 @@ import postsRouter from "./posts"
 import timelinesRouter from "./timelines"
 import albumRouter from "./album"
 import webpushRouter from "./webpush"
+import customEmojisRouter from "./customEmojis"
 import { APIRouter } from "../router-class"
 
 const router = new APIRouter()
@@ -12,5 +13,6 @@ router.use("/posts", postsRouter.routes())
 router.use("/timelines", timelinesRouter.routes())
 router.use("/album", albumRouter.routes())
 router.use("/webpush", webpushRouter.routes())
+router.use("/custom_emojis", customEmojisRouter.routes())
 
 export default router

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -10,6 +10,7 @@ import fs from "fs"
 import fileType = require("file-type")
 import sharp = require("sharp")
 import { uploadFile } from "../../../utils/uploadFile"
+import { checkCsrf } from "../../../utils/checkCsrf"
 
 const router = new Router<WebRouterState, WebRouterCustom>()
 
@@ -43,7 +44,7 @@ router.get("/new", async ctx => {
     })
 })
 
-router.post("/new", bodyParser, async ctx => {
+router.post("/new", bodyParser, checkCsrf, async ctx => {
     const { shortcode } = $.obj({ shortcode: $.string }).transformOrThrow(ctx.request.body)
     if (!/^[A-Za-z0-9_]{1,32}$/.test(shortcode)) return ctx.throw(400, "shortcodeがおかしい")
     if (null != (await getRepository(CustomEmoji).findOne({ shortcode, deletedAt: IsNull() })))

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -1,0 +1,23 @@
+import Router = require("koa-router")
+import { WebRouterState, WebRouterCustom } from ".."
+import { CustomEmojisIndex } from "../../../components/pages/settings/customEmojis"
+import { CustomEmoji } from "../../../db/entities/customEmoji"
+import { getRepository } from "typeorm"
+import $ from "transform-ts"
+
+const router = new Router<WebRouterState, WebRouterCustom>()
+
+router.get("/", async ctx => {
+    const { sort } = $.obj({ sort: $.optional($.literal("date", "name", "uploader")) }).transformOrThrow(ctx.query)
+    if (sort == null) return ctx.redirect("?sort=name")
+    const sortKey = ({
+        date: "createdAt",
+        name: "shortcode",
+        uploader: "user",
+    } as const)[sort]
+    ctx.renderReact(CustomEmojisIndex, {
+        emojis: await getRepository(CustomEmoji).find({ order: { [sortKey]: sortKey === "createdAt" ? "DESC" : "ASC" } }),
+    })
+})
+
+export default router

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -44,7 +44,7 @@ router.get("/new", async ctx => {
 
 router.post("/new", bodyParser, async ctx => {
     const { shortcode } = $.obj({ shortcode: $.string }).transformOrThrow(ctx.request.body)
-    if (!/^[A-Za-z0-9_]{1,30}$/.test(shortcode)) return ctx.throw(400, "shortcodeがおかしい")
+    if (!/^[A-Za-z0-9_]{1,32}$/.test(shortcode)) return ctx.throw(400, "shortcodeがおかしい")
     if (null != (await getRepository(CustomEmoji).findOne({ shortcode, deletedAt: IsNull() })))
         return ctx.throw(400, "そのshortcodeはもうすでに使われてる")
     const { file } = $.obj({

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -53,7 +53,7 @@ router.post("/new", bodyParser, async ctx => {
             size: $.number,
         }),
     }).transformOrThrow(ctx.request.files)
-    if (file.size > 256 * 1024 * 1024) return ctx.throw(400, "でかすぎ")
+    if (file.size > 256 * 1024) return ctx.throw(400, "でかすぎ")
     const buffer = await fs.promises.readFile(file.path)
     const type = fileType(buffer)
     if (type == null) return ctx.throw(400, "なにこのファイル")

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -30,6 +30,7 @@ router.get("/", async ctx => {
     } as const)[sort]
     ctx.renderReact(CustomEmojisIndex, {
         emojis: await getRepository(CustomEmoji).find({
+            where: { deletedAt: IsNull() },
             order: { [sortKey]: sortKey === "createdAt" ? "DESC" : "ASC" },
             relations: ["user"],
         }),

--- a/src/routers/web/settings/customEmojis.ts
+++ b/src/routers/web/settings/customEmojis.ts
@@ -2,10 +2,23 @@ import Router = require("koa-router")
 import { WebRouterState, WebRouterCustom } from ".."
 import { CustomEmojisIndex } from "../../../components/pages/settings/customEmojis"
 import { CustomEmoji } from "../../../db/entities/customEmoji"
-import { getRepository } from "typeorm"
+import { getRepository, Not, IsNull } from "typeorm"
 import $ from "transform-ts"
+import { CustomEmojisNew } from "../../../components/pages/settings/customEmojis/new"
+import koaBody = require("koa-body")
+import fs from "fs"
+import fileType = require("file-type")
+import sharp = require("sharp")
+import { uploadFile } from "../../../utils/uploadFile"
 
 const router = new Router<WebRouterState, WebRouterCustom>()
+
+const bodyParser = koaBody({
+    multipart: true,
+    urlencoded: false,
+    json: false,
+    text: false,
+})
 
 router.get("/", async ctx => {
     const { sort } = $.obj({ sort: $.optional($.literal("date", "name", "uploader")) }).transformOrThrow(ctx.query)
@@ -16,8 +29,64 @@ router.get("/", async ctx => {
         uploader: "user",
     } as const)[sort]
     ctx.renderReact(CustomEmojisIndex, {
-        emojis: await getRepository(CustomEmoji).find({ order: { [sortKey]: sortKey === "createdAt" ? "DESC" : "ASC" } }),
+        emojis: await getRepository(CustomEmoji).find({
+            order: { [sortKey]: sortKey === "createdAt" ? "DESC" : "ASC" },
+            relations: ["user"],
+        }),
     })
+})
+
+router.get("/new", async ctx => {
+    ctx.renderReact(CustomEmojisNew, {
+        csrf: ctx.state.session!.getCookieValue(),
+    })
+})
+
+router.post("/new", bodyParser, async ctx => {
+    const { shortcode } = $.obj({ shortcode: $.string }).transformOrThrow(ctx.request.body)
+    if (!/^[A-Za-z0-9_]{1,30}$/.test(shortcode)) return ctx.throw(400, "shortcodeがおかしい")
+    if (null != (await getRepository(CustomEmoji).findOne({ shortcode, deletedAt: IsNull() })))
+        return ctx.throw(400, "そのshortcodeはもうすでに使われてる")
+    const { file } = $.obj({
+        file: $.obj({
+            path: $.string,
+            size: $.number,
+        }),
+    }).transformOrThrow(ctx.request.files)
+    if (file.size > 256 * 1024 * 1024) return ctx.throw(400, "でかすぎ")
+    const buffer = await fs.promises.readFile(file.path)
+    const type = fileType(buffer)
+    if (type == null) return ctx.throw(400, "なにこのファイル")
+
+    let isLossless = false
+
+    switch (type.mime) {
+        case "image/png":
+            isLossless = true
+            break
+        case "image/jpeg":
+            break
+        default:
+            ctx.throw(400, "このファイル形式はだめ")
+            return
+    }
+    const image = sharp(buffer).rotate()
+    const meta = await image.metadata()
+    if (meta.width == null) return ctx.throw(400, "width null")
+    if (meta.height == null) return ctx.throw(400, "height null")
+    const aspect = Math.max(meta.width, meta.height) / Math.min(meta.width, meta.height)
+    if (aspect > 2) return ctx.throw(400, "縦横比やばい")
+
+    let lastImage = isLossless ? image.png() : image.jpeg({ quality: 80 })
+
+    const emoji = new CustomEmoji()
+    emoji.user = ctx.state.session!.user
+    emoji.shortcode = shortcode
+    emoji.hash = await uploadFile(await lastImage.toBuffer(), isLossless ? "png" : "jpg")
+    emoji.width = meta.width
+    emoji.height = meta.height
+    await getRepository(CustomEmoji).save(emoji)
+    ctx.redirect("/settings/custom_emojis?sort=date")
 })
 
 export default router

--- a/src/routers/web/settings/index.ts
+++ b/src/routers/web/settings/index.ts
@@ -2,11 +2,13 @@ import Router from "koa-router"
 import { WebRouterState, WebRouterCustom } from ".."
 import myDevelopedApplicationsRouter from "./myDevelopedApplications"
 import inviteCodesRouter from "./inviteCodes"
+import customEmojisRouter from "./customEmojis"
 
 const router = new Router<WebRouterState, WebRouterCustom>()
 
 router.use("/my_developed_applications", myDevelopedApplicationsRouter.routes())
 router.use("/invite_codes", inviteCodesRouter.routes())
+router.use("/custom_emojis", customEmojisRouter.routes())
 
 router.get("/", async ctx => {
     ctx.render("settings/index")

--- a/views/settings/index.pug
+++ b/views/settings/index.pug
@@ -10,3 +10,4 @@ block content
     ul
         li: a(href="/settings/invite_codes") 招待コード
         li: a(href="/settings/my_developed_applications") あなたが作ったアプリケーション一覧
+        li: a(href="/settings/custom_emojis") カスタム絵文字


### PR DESCRIPTION
resolve #263 

AlbumFile周りとはアップロード処理は別だが、アップロード先はS3なのでStorageFile周りは使う
今後のためにStorageFileにsizeを追加するマイグレーション付き

## Web 

- [x] /settings/custom_emojis で一覧表示
- [x] /settings/custom_emojis/new で登録

## API

- [ ] ~`post.customEmojis`で提供~ あとで
- [x] /api/v1/custom_emojis で提供